### PR TITLE
Disable cleanup log to console

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -157,7 +157,7 @@ Agent.prototype._init = function initSock(dtlsOpts, newCallback) {
 }
 
 Agent.prototype.finish = function finish(req) {
-  console.log("CLEANUP")
+  // console.log("CLEANUP")
   for (var k in this._msgIdToReq)
     this._msgIdToReq[k].sender.reset()
     delete this._msgIdToReq[k]


### PR DESCRIPTION
The console.log statement floods the log file of pimatic-tradfri. I guess it shouldn't be active anyway. This PR comments it out. 